### PR TITLE
index.js: Use Alfred BID

### DIFF
--- a/alfred/index.js
+++ b/alfred/index.js
@@ -12,7 +12,7 @@ try {
 } catch (error) {}
 
 try {
-  alfred = Application('Alfred 4')
+  alfred = Application('com.runningwithcrayons.Alfred')
 } catch (error) {}
 
 run = input => {


### PR DESCRIPTION
Using the bundle identifier is the preferred way to access Alfred via AppleScript / JXA because it always points to the latest installed version. See, for example, the way an [External Trigger](https://www.alfredapp.com/help/workflows/triggers/external/) suggests it:

![workflow-config-trigger-eat-bananas](https://user-images.githubusercontent.com/1699443/172497108-e6b97640-4551-46bb-9785-3702442ddbcf.png)

By the way, [someone on the forum noticed](https://www.alfredforum.com/topic/10303-smart-calculations-with-numi/page/2/#comment-95700) that apparently your wiki has an outdated download link on [its Alfred page](https://github.com/nikolaeu/numi/wiki/Alfred-Integration).